### PR TITLE
fix(google-drive): support web creds

### DIFF
--- a/langchain_googledrive/utilities/google_drive.py
+++ b/langchain_googledrive/utilities/google_drive.py
@@ -743,7 +743,7 @@ class GoogleDriveUtilities(Serializable, BaseModel):
         if api_file:
             with io.open(api_file, "r", encoding="utf-8-sig") as json_file:
                 data = json.load(json_file)
-            if "installed" in data:
+            if "installed" in data or "web" in data:
                 credentials_path = api_file
                 service_account_key = None
             else:


### PR DESCRIPTION
This change is needed so that we can support web client creds.